### PR TITLE
Add odata for vscode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The Cloud Application Programming Model (CAP) is a framework of tools, languages
 * [ESLint](https://cap.cloud.sap/docs/tools/cds-lint/) - Official ESLint rules for CAP.
 * [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds) - Language support for SAP CDS for Visual Studio Code.
 * [IntelliJ Extension](https://github.com/cap-js/cds-intellij) - SAP CDS Language Support for IntelliJ.
+* [OData for VSCode](https://marketplace.visualstudio.com/items/?itemName=manuelseeger.odata) - CoPilot enabled OData support for Visual Studio Code
 
 ## Libraries, Extensions, Plugins
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Cloud Application Programming Model (CAP) is a framework of tools, languages
 * [ESLint](https://cap.cloud.sap/docs/tools/cds-lint/) - Official ESLint rules for CAP.
 * [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=SAPSE.vscode-cds) - Language support for SAP CDS for Visual Studio Code.
 * [IntelliJ Extension](https://github.com/cap-js/cds-intellij) - SAP CDS Language Support for IntelliJ.
-* [OData for VSCode](https://marketplace.visualstudio.com/items/?itemName=manuelseeger.odata) - CoPilot enabled OData support for Visual Studio Code
+* [OData for VSCode](https://marketplace.visualstudio.com/items?itemName=manuelseeger.odata) - Copilot enabled OData support for Visual Studio Code.
 
 ## Libraries, Extensions, Plugins
 


### PR DESCRIPTION
A lot of CAP uses OData for APIs. This extension helps with working with OData services from VSCode. 

Disclaimer: I am the author of the extension.